### PR TITLE
Revert to horovod built-in load_model function

### DIFF
--- a/scripts/setup_cgpu.sh
+++ b/scripts/setup_cgpu.sh
@@ -1,3 +1,3 @@
 # Source this script to setup the runtime environment on cori
-module load cgpu tensorflow/gpu-2.2.0-py37
+module load cgpu tensorflow/2.4.1-gpu
 module list


### PR DESCRIPTION
Fixes #30

This removes my workaround for loading model+optimizer from https://github.com/horovod/horovod/issues/1920
I no longer need the custom function to wrap the DistributedOptimizer. The built-in horovod load_model seems fine now.