### PR TITLE
Adding mlperf log events for weak-scaling metrics

### DIFF
--- a/train.py
+++ b/train.py
@@ -233,6 +233,10 @@ def main():
     if dist.rank == 0 and args.mlperf:
         mllogger.event(key=mllog.constants.CACHE_CLEAR)
         mllogger.start(key=mllog.constants.INIT_START)
+        # Scale logging for mlperf hpc metrics
+        mllogger.event(key='number_of_ranks', value=dist.size)
+        mllogger.event(key='number_of_nodes', value=(dist.size//dist.local_size))
+        mllogger.event(key='accelerators_per_node', value=dist.local_size)
 
     # Initialize Weights & Biases logging
     if args.wandb and dist.rank == 0:


### PR DESCRIPTION
Now logging
- number_of_ranks (not required but useful)
- number_of_nodes (required)
- accelerators_per_node (required)