### PR TITLE
Fix shard + shuffle

### DIFF
--- a/configs/cosmo_rcp_1024.yaml
+++ b/configs/cosmo_rcp_1024.yaml
@@ -2,7 +2,7 @@ output_dir: results/cosmo-rcp-1024
 
 data:
     name: cosmo
-    data_dir: /global/cscratch1/sd/sfarrell/cosmoflow-benchmark/data/cosmoUniverse_2019_05_4parE_tf_v2
+    data_dir: /pscratch/sd/s/sfarrell/cosmoflow-benchmark/data/cosmoUniverse_2019_05_4parE_tf_v2
     compression: GZIP
     n_train: 524288
     n_valid: 65536

--- a/data/cosmo.py
+++ b/data/cosmo.py
@@ -111,9 +111,9 @@ def construct_dataset(file_dir, n_samples, batch_size, n_epochs,
 
     # Define the dataset from the list of sharded, shuffled files
     data = tf.data.Dataset.from_tensor_slices(filenames)
-    data = data.shard(num_shards=n_shards, index=shard)
     if shuffle:
         data = data.shuffle(len(filenames), reshuffle_each_iteration=True)
+    data = data.shard(num_shards=n_shards, index=shard)
 
     # Parse TFRecords
     parse_data = partial(_parse_data, shape=sample_shape, apply_log=apply_log)

--- a/scripts/train_pm_shifter.sh
+++ b/scripts/train_pm_shifter.sh
@@ -15,7 +15,7 @@ set -x
 
 # Run the dummy cuda app to "fix" cuda init errors
 #echo "int main() {cudaFree(0);}" > dummy.cu && nvcc -o dummy dummy.cu
-srun ./dummy
+#srun ./dummy
 
 # Run the container
 srun -l -u --mpi=pmi2 shifter --module=gpu \

--- a/train.py
+++ b/train.py
@@ -118,14 +118,11 @@ def parse_args():
     add_arg('--amp', action='store_true', help='Enable automatic mixed precision')
 
     # Other settings
-    add_arg('--mlperf', action='store_true',
-            help='Enable MLPerf logging')
-    add_arg('--wandb', action='store_true',
-            help='Enable W&B logging')
-    add_arg('--tensorboard', action='store_true',
-            help='Enable TB logger')
-    add_arg('--print-fom', action='store_true',
-            help='Print parsable figure of merit')
+    add_arg('--seed', type=int, default=0, help='Specify the random seed')
+    add_arg('--mlperf', action='store_true', help='Enable MLPerf logging')
+    add_arg('--wandb', action='store_true', help='Enable W&B logging')
+    add_arg('--tensorboard', action='store_true', help='Enable TB logger')
+    add_arg('--print-fom', action='store_true', help='Print parsable figure of merit')
     add_arg('-v', '--verbose', action='store_true')
     return parser.parse_args()
 
@@ -226,6 +223,10 @@ def main():
                  dist.rank, dist.size, dist.local_rank, dist.local_size)
     if dist.rank == 0:
         logging.info('Configuration: %s', config)
+
+    # Random seeding
+    tf.random.set_seed(args.seed)
+    np.random.seed(args.seed)
 
     # Setup MLPerf logging
     if args.mlperf:


### PR DESCRIPTION
This should fix #41 .

Moves the dataset per-rank sharding after the shuffling to fix support for full global shuffling.
This of course requires random shuffling consistency across ranks to work properly, so we finally introduce random seed setting here as well.