### PR TITLE
Reproducibility updates

### DIFF
--- a/train.py
+++ b/train.py
@@ -226,9 +226,7 @@ def main():
         logging.info('Configuration: %s', config)
 
     # Random seeding
-    random.seed(args.seed)
-    np.random.seed(args.seed)
-    tf.random.set_seed(args.seed)
+    tf.keras.utils.set_random_seed(args.seed)
 
     # Setup MLPerf logging
     if args.mlperf:

--- a/train.py
+++ b/train.py
@@ -34,7 +34,6 @@ import os
 import argparse
 import logging
 import pickle
-import random
 from types import SimpleNamespace
 
 # External imports

--- a/train.py
+++ b/train.py
@@ -236,6 +236,7 @@ def main():
     if dist.rank == 0 and args.mlperf:
         mllogger.event(key=mllog.constants.CACHE_CLEAR)
         mllogger.start(key=mllog.constants.INIT_START)
+        mllogger.start(key=mllog.constants.SEED, value=args.seed)
         # Scale logging for mlperf hpc metrics
         mllogger.event(key='number_of_ranks', value=dist.size)
         mllogger.event(key='number_of_nodes', value=(dist.size//dist.local_size))

--- a/train.py
+++ b/train.py
@@ -120,6 +120,8 @@ def parse_args():
 
     # Other settings
     add_arg('--seed', type=int, default=0, help='Specify the random seed')
+    add_arg('--deterministic-ops', action='store_true',
+            help='Enable TF deterministic ops (may not be 100% deterministic)')
     add_arg('--mlperf', action='store_true', help='Enable MLPerf logging')
     add_arg('--wandb', action='store_true', help='Enable W&B logging')
     add_arg('--tensorboard', action='store_true', help='Enable TB logger')
@@ -227,6 +229,11 @@ def main():
 
     # Random seeding
     tf.keras.utils.set_random_seed(args.seed)
+
+    # Enable deterministic ops - should ensure single-gpu determinism but
+    # doesn't seem to guarantee determinism with Horovod distributed training
+    if args.deterministic_ops:
+        tf.config.experimental.enable_op_determinism()
 
     # Setup MLPerf logging
     if args.mlperf:

--- a/train.py
+++ b/train.py
@@ -34,6 +34,7 @@ import os
 import argparse
 import logging
 import pickle
+import random
 from types import SimpleNamespace
 
 # External imports
@@ -225,8 +226,9 @@ def main():
         logging.info('Configuration: %s', config)
 
     # Random seeding
-    tf.random.set_seed(args.seed)
+    random.seed(args.seed)
     np.random.seed(args.seed)
+    tf.random.set_seed(args.seed)
 
     # Setup MLPerf logging
     if args.mlperf:


### PR DESCRIPTION
Switched to keras utility function for setting all random seeds.
Added mlperf logging of the random seed (previously missing).
Added switch to enable deterministic ops in TF, which seems to make things deterministic on a single gpu but doesn't guarantee determinism when running distributed training with horovod.